### PR TITLE
Fix capital case error in autohaendler2.json

### DIFF
--- a/public/tasks/autohaendler2.json
+++ b/public/tasks/autohaendler2.json
@@ -131,7 +131,7 @@
         "Verkaufspreis",
         "PS",
         "Baujahr",
-        "KM",
+        "km",
         "Einkaufspreis"
       ],
       "type": "voll"
@@ -150,7 +150,7 @@
         "Verkaufspreis",
         "PS",
         "Baujahr",
-        "KM",
+        "km",
         "Einkaufspreis"
       ]
     }
@@ -280,7 +280,7 @@
         "Verkaufspreis",
         "Einkaufspreis",
         "Baujahr",
-        "KM"
+        "km"
       ]
     }
   ],


### PR DESCRIPTION
Currently, it is not possible to answer the last task "Autohändler 2" correctly, because there is a case mismatch in the `autohaendler2.json` file (the word "km" is written in lower case in the schema, but in capital case in the solutions).
This PR provides a simple fix. 